### PR TITLE
Reading default values for prompts from config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ci",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ci",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "react-native-ci CLI",
   "bin": {
     "react-native-ci": "bin/react-native-ci"

--- a/readme.md
+++ b/readme.md
@@ -39,8 +39,30 @@ Run command in your project root:
 react-native-ci init
 ```
 
-Provide the required information when prompted.
+Provide the required information when prompted. Optionally you can define config file, which includes
+default values to the questions. This is useful when you test command multiple times and don't want
+to have to input all the values manually each time. Especially useful when developing and testing
+react-native-ci itself!
 
+Example config file: (react-native-ci.config.js)
+
+```
+module.exports = {
+    defaults: {
+        githubOrg: "org-name",
+        repo: "github-repo",
+        circleApi: "circleApiToken",
+        googleJsonPath: "path/to/google/json",
+        appleDevAccount: "dev@company.com",
+        iTunesTeamId: "itunes-team-id",
+        appConnectTeamId: "app-connect-team-id",
+        certRepoUrl: "git@github.com:company/project-ios-certs.git",
+        appId: "com.company.greatapp",
+        matchPassword: "password",
+    }
+}
+
+```
 
 ## What does it actually do?
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -7,8 +7,11 @@ module.exports = {
     const { runAndroid } = require('../flows/android')
     const { runIOS } = require('../flows/ios')
 
-    const sharedConfig = await runShared(toolbox, {})
-    await runAndroid(toolbox, sharedConfig)
-    await runIOS(toolbox, sharedConfig)
+    const { print: { info } } = toolbox
+    info(process.cwd())
+    const defaultConfig = toolbox.config.loadConfig('react-native-ci', process.cwd())
+    const sharedConfig = await runShared(toolbox, defaultConfig)
+    await runAndroid(toolbox, { ...defaultConfig, ...sharedConfig })
+    await runIOS(toolbox, { ...defaultConfig, ...sharedConfig })
   }
 }

--- a/src/flows/android.js
+++ b/src/flows/android.js
@@ -4,18 +4,19 @@ module.exports.runAndroid = async (toolbox, config) => {
   await setupGradle(toolbox, config)
 }
 
-const askQuestion = async (prompt) => {
+const askQuestion = async (prompt, defaults = {}) => {
   const askGooglePlayJSONPath = {
     type: 'input',
+    initial: defaults.googleJsonPatch,
     name: 'jsonPath',
     message: 'Path to Google Play Store JSON?'
   }
   return prompt.ask(askGooglePlayJSONPath)
 }
 
-const initAndroid = async ({ android, http, prompt, print }, { project, org, apiToken }) => {
+const initAndroid = async ({ android, http, prompt, print }, { project, org, apiToken, defaults }) => {
 
-  const { jsonPath } = await askQuestion(prompt)
+  const { jsonPath } = await askQuestion(prompt, defaults)
 
   const keystoreFiles = await android.createKeystore({
     name: project,

--- a/src/flows/ios.js
+++ b/src/flows/ios.js
@@ -1,5 +1,5 @@
 module.exports.runIOS = async (toolbox, config) =>  {
-  const input = await getInput(toolbox)
+  const input = await getInput(toolbox, config)
   await initFastlane(toolbox, {
     ...config,
     ...input
@@ -157,7 +157,7 @@ const initFastlane = async ({ ios, system, template, filesystem, http, prompt, p
 }
 
 
-const getInput = async ({ system, filesystem, prompt }) => {
+const getInput = async ({ system, filesystem, prompt }, { defaults = {} }) => {
   const xcodeProjectName = filesystem.find('ios/', {
     matching: '*.xcodeproj',
     directories: true,
@@ -168,35 +168,41 @@ const getInput = async ({ system, filesystem, prompt }) => {
 
   const askDeveloperAccount = {
     type: 'input',
+    initial: defaults.appleDevAccount,
     name: 'developerAccount',
     message: 'Your Apple developer account?'
   }
   const askITunesTeamId = {
     type: 'input',
+    initial: defaults.iTunesTeamId,
     name: 'developerTeamId',
     message: 'Your iTunes Team ID?'
   }
 
   const askAppConnectTeamId = {
     type: 'input',
+    initial: defaults.appConnectTeamId,
     name: 'iTunesTeamId',
     message: 'App Connect Team ID?'
   }
 
   const askCertRepo = {
     type: 'input',
+    initial: defaults.certRepoUrl,
     name: 'certRepo',
     message: 'Specify path to iOS Signing key repo'
   }
 
   const askAppId = {
     type: 'input',
+    initial: defaults.appId,
     name: 'appId',
     message: 'What is your app bundle id?'
   }
 
   const askMatchPassword = {
     type: 'input',
+    initial: defaults.matchPassword,
     name: 'matchPassword',
     message: 'What do you want to be your match repo password?'
   }

--- a/src/flows/shared.js
+++ b/src/flows/shared.js
@@ -1,23 +1,26 @@
 module.exports.runShared = async (toolbox, config) =>  {
-  const answers = await askQuestions(toolbox)
+  const answers = await askQuestions(toolbox, config)
   await initCircleCI(toolbox, config)
   return answers
 }
 
-const askQuestions = async ({ prompt }) => {
+const askQuestions = async ({ prompt }, { defaults = {} }) => {
   // text input
   const askOrganization = {
     type: 'input',
+    initial: defaults.githubOrg,
     name: 'org',
     message: 'Your github organization?'
   }
   const askProject = {
     type: 'input',
+    initial: defaults.repo,
     name: 'project',
     message: 'Your github project name?'
   }
   const askApiToken = {
     type: 'input',
+    initial: defaults.circleApi,
     name: 'apiToken',
     message: 'Your CircleCI API token?'
   }


### PR DESCRIPTION
Allows defining config file to read default values for prompts, making it easier to run the command multiple times, for example while developing react-native-ci itself.

Fixes #12 