### PR TITLE
Append platform OS to cache id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ci",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "react-native-ci CLI",
   "bin": {
     "react-native-ci": "bin/react-native-ci"

--- a/src/templates/circleci/config.yml
+++ b/src/templates/circleci/config.yml
@@ -98,10 +98,10 @@ jobs:
         path: ~/project
 
     - restore_cache:
-        key: react-native-ci-{{ checksum "../package-lock.json" }}
+        key: react-native-ci-iOS-{{ checksum "../package-lock.json" }}
     - run: npm install
     - save_cache:
-        key: react-native-ci-{{ checksum "../package-lock.json" }}
+        key: react-native-ci-iOS-{{ checksum "../package-lock.json" }}
         paths:
         - ../node_modules
 


### PR DESCRIPTION
Without it, test job tries to find iOS cache and circleci build fails