### PR TITLE
fix(ios): Automate team id selection

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -10,6 +10,7 @@ module.exports = {
     const { print: { info } } = toolbox
     info(process.cwd())
     const defaultConfig = toolbox.config.loadConfig('react-native-ci', process.cwd())
+    const sharedConfig = {}
     const sharedConfig = await runShared(toolbox, defaultConfig)
     await runAndroid(toolbox, { ...defaultConfig, ...sharedConfig })
     await runIOS(toolbox, { ...defaultConfig, ...sharedConfig })

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -10,7 +10,6 @@ module.exports = {
     const { print: { info } } = toolbox
     info(process.cwd())
     const defaultConfig = toolbox.config.loadConfig('react-native-ci', process.cwd())
-    const sharedConfig = {}
     const sharedConfig = await runShared(toolbox, defaultConfig)
     await runAndroid(toolbox, { ...defaultConfig, ...sharedConfig })
     await runIOS(toolbox, { ...defaultConfig, ...sharedConfig })

--- a/src/extensions/circle-extension.js
+++ b/src/extensions/circle-extension.js
@@ -1,0 +1,33 @@
+module.exports = toolbox => {
+    toolbox.circle = {
+      postEnvVariable: async ({ 
+        org, 
+        project,
+        apiToken,
+        key, 
+        value
+      }) => {
+        const { http } = toolbox
+        const api = http.create({
+          baseURL: 'https://circleci.com/api/v1.1/'
+        })
+      
+        await api.post(
+          `project/github/${org}/${project}/envvar?circle-token=${apiToken}`,
+          {name: key, value: value },
+          {headers: {'Content-Type': 'application/json'}}
+        )
+      },
+      followProject: async ({ org, project, apiToken}) => {
+        const { http } = toolbox
+        const api = http.create({
+          baseURL: 'https://circleci.com/api/v1.1/'
+        })
+      
+        const { status } = await api.post(
+          `project/github/${org}/${project}/follow?circle-token=${apiToken}`
+        )
+        return status  
+      }
+    }
+}  

--- a/src/extensions/ios-extension.js
+++ b/src/extensions/ios-extension.js
@@ -9,10 +9,12 @@ module.exports = toolbox => {
         resolve()
       })
     },
-    addBuildConfigurations: async (teamId) => {
+    addBuildConfigurations: async teamId => {
       const { print, system, meta } = toolbox
       return new Promise((resolve, reject) => {
-        system.run(`ruby ${meta.src}/ios.rb make_new_build_configurations ${teamId}`)
+        system.run(
+          `ruby ${meta.src}/ios.rb make_new_build_configurations ${teamId}`
+        )
         resolve()
       })
     },
@@ -34,19 +36,92 @@ module.exports = toolbox => {
         resolve()
       })
     },
-    produceApp: async ({ appId, devId, appName, developerTeamId, iTunesTeamId}) => {
+    produceApp: async ({
+      appId,
+      devId,
+      appName,
+      developerTeamId,
+      iTunesTeamId
+    }) => {
       const { print, system } = toolbox
       return new Promise((resolve, reject) => {
-        const output = system.run(`fastlane produce -u ${devId} -a ${appId} --app_name "${appName}" --team_id "${developerTeamId}" --itc_team_id "${iTunesTeamId}"`)
+        const output = system.run(
+          `fastlane produce -u ${devId} -a ${appId} --app_name "${appName}" --team_id "${developerTeamId}" --itc_team_id "${iTunesTeamId}"`
+        )
         resolve(output)
       })
     },
     matchSync: async ({ certType, password }) => {
       const { print, system } = toolbox
       return new Promise((resolve, reject) => {
-        const output = system.run(`cd ios && (export MATCH_PASSWORD=${password}; bundle exec fastlane match ${certType})`)
+        const output = system.run(
+          `cd ios && (export MATCH_PASSWORD=${password}; bundle exec fastlane match ${certType})`
+        )
         resolve(output)
+      })
+    },
+    getTeamIds: async accountInfo => {
+      const { print, system, meta } = toolbox
+      return new Promise(async (resolve, reject) => {
+        try {
+          const devTeams = await parseTeam('dev', accountInfo, meta.src)
+          const itcTeams = await parseTeam('itc', accountInfo, meta.src)
+          const teams = {
+            itcTeams: itcTeams,
+            devTeams: devTeams
+          }
+          resolve(teams)
+        } catch (e) {
+          reject(e)
+        }
       })
     }
   }
+}
+
+const parseTeam = async (
+  teamType,
+  { developerAccount, developerPassword },
+  path
+) => {
+  return new Promise((resolve, reject) => {
+    const spawn = require('child_process').spawn
+    const child = spawn('ruby', [
+      `${path}/ios.rb`,
+      'get_team_id',
+      teamType,
+      developerAccount,
+      developerPassword
+    ])
+    child.stdout.on('data', data => {
+      const dataStr = data.toString()
+      const regexpTeamLine = new RegExp(/^\d+[)]/)
+      const regexpTeamName = new RegExp(/"(.*?)"/)
+      const lines = dataStr.split('\n')
+      const teams = []
+      //if only one team found
+      if (lines.length === 2 && lines[1].length === 0) {
+        teams.push(lines[0])
+        resolve(teams)
+      }
+      //parse multiple teams
+      const regexpTeamId =
+        teamType === 'dev' ? new RegExp(/\)(.*?)"/) : new RegExp(/\((.*?)\)/)
+      lines.forEach(line => {
+        if (regexpTeamLine.test(line)) {
+          const teamName = regexpTeamName.exec(line)[1]
+          const teamId = regexpTeamId.exec(line)[1].trim()
+          teams.push({ name: teamName, id: teamId })
+        }
+      })
+      if (teams.length === 0) {
+        reject('Not able to retrieve teams, check account credentials')
+      }
+      resolve(teams)
+    })
+    child.stderr.on('data', data => {
+      reject('Not able to retrieve teams, check account credentials')
+    })
+    child.stdin.write('2\n')
+  })
 }

--- a/src/extensions/ios-extension.js
+++ b/src/extensions/ios-extension.js
@@ -39,6 +39,7 @@ module.exports = toolbox => {
     produceApp: async ({
       appId,
       devId,
+      developerPassword,
       appName,
       developerTeamId,
       iTunesTeamId

--- a/src/extensions/npm-extension.js
+++ b/src/extensions/npm-extension.js
@@ -1,5 +1,3 @@
-// add your CLI-specific functionality here, which will then be accessible
-// to your commands
 const install = require('install-packages')
 
 module.exports = toolbox => {

--- a/src/flows/android.js
+++ b/src/flows/android.js
@@ -14,7 +14,7 @@ const askQuestion = async (prompt, defaults = {}) => {
   return prompt.ask(askGooglePlayJSONPath)
 }
 
-const initAndroid = async ({ android, http, prompt, print }, { project, org, apiToken, defaults }) => {
+const initAndroid = async ({ android, http, prompt, print, circle }, { project, org, apiToken, defaults }) => {
 
   const { jsonPath } = await askQuestion(prompt, defaults)
 
@@ -26,31 +26,33 @@ const initAndroid = async ({ android, http, prompt, print }, { project, org, ap
   })
 
   print.info('Store keystore to secret variables')
-  const api = http.create({
-    baseURL: 'https://circleci.com/api/v1.1/'
+  circle.postEnvVariable({
+    org,
+    project,
+    apiToken,
+    key: 'KEYSTORE',
+    value: keystoreFiles.encodedKeystore
   })
 
-  await api.post(
-    `project/github/${org}/${project}/envvar?circle-token=${apiToken}`,
-    {name: 'KEYSTORE', value: keystoreFiles.encodedKeystore},
-    {headers: {'Content-Type': 'application/json'}}
-  )
-
   print.info('Store keystore properties to secret variables')
-  await api.post(
-    `project/github/${org}/${project}/envvar?circle-token=${apiToken}`,
-    {name: 'KEYSTORE_PROPERTIES', value: keystoreFiles.keystoreProperties},
-    {headers: {'Content-Type': 'application/json'}}
-  )
+  circle.postEnvVariable({
+    org,
+    project,
+    apiToken,
+    key: 'KEYSTORE_PROPERTIES',
+    value: keystoreFiles.keystoreProperties
+  })
 
   if (jsonPath !== '' && jsonPath !== undefined) {
     print.info('Store Google Play JSON to secret variables')
     const encodedPlayStoreJSON = android.base64EncodeJson(jsonPath)
-    await api.post(
-      `project/github/${org}/${project}/envvar?circle-token=${apiToken}`,
-      {name: 'GOOGLE_PLAY_JSON', value: encodedPlayStoreJSON},
-      {headers: {'Content-Type': 'application/json'}}
-    )
+    circle.postEnvVariable({
+      org,
+      project,
+      apiToken,
+      key: 'GOOGLE_PLAY_JSON',
+      value: encodedPlayStoreJSON
+    })
   }
 }
 

--- a/src/flows/ios.js
+++ b/src/flows/ios.js
@@ -1,4 +1,4 @@
-module.exports.runIOS = async (toolbox, config) =>  {
+module.exports.runIOS = async (toolbox, config) => {
   const input = await getInput(toolbox, config)
   await initFastlane(toolbox, {
     ...config,
@@ -10,37 +10,48 @@ module.exports.runIOS = async (toolbox, config) =>  {
   })
 }
 
-const initXcode = async ({ print: { spin }, template, npm, system, ios }, config) => {
+const initXcode = async (
+  { print: { spin }, template, npm, system, ios },
+  config
+) => {
   const iosSpinner = spin('Modifying iOS Project')
   await ios.addSchemes()
   await ios.addBuildConfigurations(config.developerTeamId)
   await ios.addBundleIdSuffixes()
-  await system.run(`cd ios && fastlane run update_info_plist 'display_name:$(CUSTOM_PRODUCT_NAME)' plist_path:${config.projectName}/Info.plist`)
+  await system.run(
+    `cd ios && fastlane run update_info_plist 'display_name:$(CUSTOM_PRODUCT_NAME)' plist_path:${
+      config.projectName
+    }/Info.plist`
+  )
 
   iosSpinner.succeed('iOS Project modified')
 
-  const rnConfigSpinner = spin('Installing and configuring react-native-config..')
+  const rnConfigSpinner = spin(
+    'Installing and configuring react-native-config..'
+  )
   await npm.installPackage('react-native-config')
-  await system.spawn('react-native link react-native-config', { stdio: 'ignore'})
+  await system.spawn('react-native link react-native-config', {
+    stdio: 'ignore'
+  })
   rnConfigSpinner.succeed('react-native-config installed')
 
   const envSpinner = spin('Generating environment config files..')
   await template.generate({
     template: '.env.ejs',
     target: '.env.dev',
-    props: { env: 'DEV'}
+    props: { env: 'DEV' }
   })
 
   await template.generate({
     template: '.env.ejs',
     target: '.env.staging',
-    props: { env: 'STAGING'}
+    props: { env: 'STAGING' }
   })
 
   await template.generate({
     template: '.env.ejs',
     target: '.env.prod',
-    props: { env: 'PRODUCTION'}
+    props: { env: 'PRODUCTION' }
   })
   envSpinner.succeed('Environments generated')
 
@@ -53,22 +64,29 @@ const initXcode = async ({ print: { spin }, template, npm, system, ios }, config
   npm.addConfigSection({
     key: 'xcodeSchemes',
     value: {
-      Debug: [
-        'Dev Debug',
-        'Staging Debug'
-      ],
-      Release: [
-        'Dev Release',
-        'Staging Release'
-      ],
-      'projectDirectory': 'iOS'
+      Debug: ['Dev Debug', 'Staging Debug'],
+      Release: ['Dev Release', 'Staging Release'],
+      projectDirectory: 'iOS'
     }
   })
   await system.exec('npm run postinstall')
   spinner.succeed('react-native-schemes-manager installed..')
 }
 
-const initFastlane = async ({ ios, system, template, filesystem, http, circle, prompt, print, print: { info, spin, success } }, config) => {
+const initFastlane = async (
+  {
+    ios,
+    system,
+    template,
+    filesystem,
+    http,
+    circle,
+    prompt,
+    print,
+    print: { info, spin, success }
+  },
+  config
+) => {
   const flSpinner = spin('Preparing Fastlane for iOS..')
   const fastlanePath = system.which('fastlane')
   if (!fastlanePath) {
@@ -91,7 +109,7 @@ const initFastlane = async ({ ios, system, template, filesystem, http, circle, p
 
   flSpinner.start()
 
-  const { appId } = config
+  const { appId } = config
 
   await template.generate({
     template: 'fastlane/ios/Matchfile',
@@ -106,7 +124,7 @@ const initFastlane = async ({ ios, system, template, filesystem, http, circle, p
   await template.generate({
     template: 'fastlane/ios/Pluginfile',
     target: 'ios/fastlane/Pluginfile',
-    props: { }
+    props: {}
   })
 
   await template.generate({
@@ -118,6 +136,8 @@ const initFastlane = async ({ ios, system, template, filesystem, http, circle, p
       slackHook: config.slackHook
     }
   })
+
+  await system.run(`fastlane fastlane-credentials add --username ${config.developerAccount} --password ${config.developerPassword}`)
 
   await ios.produceApp({
     appId,
@@ -141,7 +161,10 @@ const initFastlane = async ({ ios, system, template, filesystem, http, circle, p
     iTunesTeamId: config.iTunesTeamId
   })
   await ios.matchSync({ certType: 'appstore', password: config.matchPassword })
-  await ios.matchSync({ certType: 'development', password: config.matchPassword })
+  await ios.matchSync({
+    certType: 'development',
+    password: config.matchPassword
+  })
 
   const { org, project, apiToken } = config
   circle.postEnvVariable({
@@ -164,13 +187,15 @@ const initFastlane = async ({ ios, system, template, filesystem, http, circle, p
   success(`${print.checkmark} Fastlane iOS setup success`)
 }
 
-
-const getInput = async ({ system, filesystem, prompt, ios, print }, { defaults = {} }) => {
+const getInput = async (
+  { system, filesystem, prompt, ios, print },
+  { defaults = {} }
+) => {
   const xcodeProjectName = filesystem.find('ios/', {
     matching: '*.xcodeproj',
     directories: true,
     recursive: false,
-    files: false,
+    files: false
   })[0]
   const projectName = xcodeProjectName.split(/\/|\./)[1]
 
@@ -185,7 +210,7 @@ const getInput = async ({ system, filesystem, prompt, ios, print }, { defaults =
       type: 'password',
       name: 'developerPassword',
       message: 'Your Apple developer password?'
-    },
+    }
   ])
 
   let itcTeams = []
@@ -205,18 +230,26 @@ const getInput = async ({ system, filesystem, prompt, ios, print }, { defaults =
   }
   teamSpinner.succeed('Apple teams search successful')
 
-  const developerTeamId = await promptForTeamId(devTeams, {
-    message: 'Your Developer Team ID?',
-    multiMessage: 'Please select the developer team you want to use'
-  }, prompt)
-  
-  const iTunesTeamId = await promptForTeamId(itcTeams, {
-    message: 'Your App connect Team ID?',
-    multiMessage: 'Please select the app connect team you want to use'
-  }, prompt)
+  const developerTeamId = await promptForTeamId(
+    devTeams,
+    {
+      message: 'Your Developer Team ID?',
+      multiMessage: 'Please select the developer team you want to use'
+    },
+    prompt
+  )
 
-//  print.info(`dev team id: ${developerTeamId}`)
-//  print.info(`app team id: ${iTunesTeamId}`)
+  const iTunesTeamId = await promptForTeamId(
+    itcTeams,
+    {
+      message: 'Your App connect Team ID?',
+      multiMessage: 'Please select the app connect team you want to use'
+    },
+    prompt
+  )
+
+   print.info(`dev team id: ${developerTeamId}`)
+   print.info(`app team id: ${iTunesTeamId}`)
 
   const askCertRepo = {
     type: 'input',
@@ -247,7 +280,7 @@ const getInput = async ({ system, filesystem, prompt, ios, print }, { defaults =
     developerAccount,
     developerPassword,
     developerTeamId,
-    itunesTeamId,
+    iTunesTeamId,
     slackHook: '',
     projectName
   }
@@ -258,7 +291,12 @@ const promptForTeamId = async (teams, { message, multiMessage }, prompt) => {
     const { teamId } = await prompt.ask({
       type: 'select',
       name: 'teamId',
-      choices: teams.map((team) => `${team.name} (${team.id})`),
+      choices: teams.map(team => {
+        return {
+          name: team.id,
+          message: `${team.name} (${team.id})`,
+        }
+      }),
       message: multiMessage
     })
     return teamId

--- a/src/flows/shared.js
+++ b/src/flows/shared.js
@@ -29,7 +29,7 @@ const askQuestions = async ({ prompt }, { defaults = {} }) => {
   return prompt.ask(questions)
 }
 
-const initCircleCI = async ({ template, prompt, print, http, android }, { org, project, apiToken, jsonPath }) => {
+const initCircleCI = async ({ template, prompt, print, http, android, circle }, { org, project, apiToken, jsonPath }) => {
   await template.generate({
     template: 'circleci/config.yml',
     target: '.circleci/config.yml',

--- a/src/ios.rb
+++ b/src/ios.rb
@@ -106,6 +106,19 @@ def add_schemes(project_path)
   main_scheme.save_as(project_path, basename + "Staging", shared=true)
 end
 
+def get_team_id(team_type, account, password)
+  require 'spaceship'
+  if (team_type == 'itc')
+    Spaceship::Tunes.login(account, password)
+    team_id = Spaceship::Tunes.select_team  
+    team_id
+  elsif (team_type == 'dev')
+    Spaceship::Portal.login(account, password)
+    team_id = Spaceship::Portal.select_team      
+    team_id
+  end
+end
+
 def get_project_path()
   Dir["ios/*.xcodeproj"].select {|f| File.directory? f}.first
 end
@@ -125,6 +138,12 @@ elsif COMMAND == "add_bundle_id_suffixes"
   project.save
 elsif COMMAND == "get_project_path"
   get_project_path
+elsif COMMAND == "get_team_id"
+  team_type = ARGV[1]
+  account = ARGV[2]
+  password = ARGV[3]
+  team_id = get_team_id(team_type, account, password)
+  puts team_id
 end
 
 


### PR DESCRIPTION
fix(ios): Automate team id selection, prompt if more user has more than one team
fix(ios): Save dev account password into CircleCI env variable (FASTLANE_PASSWORD) for CI access to dev account for deployments
fix(circle): Create circle extension and move circle specific flows there

Fixes #18 