### PR TITLE
Find iOS bundle id automatically if possible

### DIFF
--- a/src/extensions/ios-extension.js
+++ b/src/extensions/ios-extension.js
@@ -76,6 +76,15 @@ module.exports = toolbox => {
           reject(e)
         }
       })
+    },
+    getAppId: async () => {
+      const { print, system, meta } = toolbox
+      return new Promise((resolve, reject) => {
+        const appId = system.run(
+          `ruby ${meta.src}/ios.rb get_app_id`
+        , { trim: true })
+        resolve(appId)
+      })
     }
   }
 }

--- a/src/flows/ios.js
+++ b/src/flows/ios.js
@@ -251,6 +251,7 @@ const getInput = async (
    print.info(`dev team id: ${developerTeamId}`)
    print.info(`app team id: ${iTunesTeamId}`)
 
+
   const askCertRepo = {
     type: 'input',
     initial: defaults.certRepoUrl,
@@ -258,11 +259,17 @@ const getInput = async (
     message: 'Specify path to iOS Signing key repo'
   }
 
+  const appId = await ios.getAppId()
+  const isValidAppId = await prompt.confirm( 
+    `We resolved Bundle ID for your project: ${appId}, is this correct?`
+  )
+
   const askAppId = {
     type: 'input',
     initial: defaults.appId,
     name: 'appId',
-    message: 'What is your app bundle id?'
+    skip: isValidAppId,
+    message: 'What is your project Bundle ID?'
   }
 
   const askMatchPassword = {
@@ -273,9 +280,11 @@ const getInput = async (
   }
 
   // ask a series of questions
-  const questions = [askCertRepo, askAppId, askMatchPassword]
+  const questions = [askAppId, askCertRepo, askMatchPassword]
+
   const answers = await prompt.ask(questions)
   return {
+    appId,
     ...answers,
     developerAccount,
     developerPassword,


### PR DESCRIPTION
Tries to resolve bundle id from iOS project
- Looks for CFBundleIdentifier from Info.plist
- Resolves build setting variables recursively
- Support for :lower and :rfc1034identifier transformations, which are probably the most used for bundle id.

User is prompted to confirm value. If it is incorrect, user is able to input their own custom value.

Fixes #17 