### PR TITLE
Default to .aab builds with Play Store

### DIFF
--- a/src/flows/android.js
+++ b/src/flows/android.js
@@ -62,12 +62,19 @@ const initAndroid = async ({ android, http, prompt, print, circle }, options) =>
   }
 }
 
-const initFastlane = async ({ system, android, template, filesystem, print }) => {
+const initFastlane = async ({ system, android, template, filesystem, print, prompt }) => {
   const fastlanePath = system.which('fastlane')
   if (!fastlanePath) {
     print.info('No fastlane found, install...')
     await system.run('sudo gem install fastlane -NV')
   }
+
+  const { buildMode } = await prompt.ask({
+    type: 'select',
+    name: 'buildMode',
+    message: 'Use Android App Bundle (.aab) or Android Package Kit (.apk) builds for Play Store?',
+    choices: ['.aab', '.apk'],
+  })
 
   const appId = android.getApplicationId()
 
@@ -80,7 +87,7 @@ const initFastlane = async ({ system, android, template, filesystem, print }) =>
   await template.generate({
     template: 'fastlane/android/Fastfile',
     target: 'android/fastlane/Fastfile',
-    props: { appId }
+    props: { appId, useAabBuilds: buildMode === '.aab' }
   })
 
   await template.generate({

--- a/src/templates/fastlane/android/Fastfile
+++ b/src/templates/fastlane/android/Fastfile
@@ -41,8 +41,9 @@ platform :android do
 
     build_number = number_of_commits()
     gradle(
-      task: 'bundle',
-      build_type: build_type,
+     <%if (props.useAabBuilds) { -%> task: 'bundle',
+     <% } else { -%> task: 'assemble',
+     <% } -%> build_type: build_type,
       properties: {
         "VERSION_CODE" => build_number
       }
@@ -78,7 +79,9 @@ platform :android do
     upload_to_play_store(
       package_name:  "<%= props.appId %>#{package_name_postfix}",
       track: 'internal',
-      aab: "./app/build/outputs/bundle/#{env}/app.aab"
+     <% if (props.useAabBuilds) { -%> aab: "./app/build/outputs/bundle/#{env}/app.aab"-%>
+     <% } else { -%> apk: "./app/build/outputs/apk/#{env}/release/app-#{env}-release.apk"-%>
+     <% } %>
     )
   end
 end

--- a/src/templates/fastlane/android/Fastfile
+++ b/src/templates/fastlane/android/Fastfile
@@ -70,7 +70,6 @@ platform :android do
     if env != 'dev' and env != 'staging' and env != 'release' then
       raise 'env must be one of dev|staging|release'
     end
-    env_name = env.capitalize
     package_name_postfix = {
       'release' => '',
       'dev' => '.dev',

--- a/src/templates/fastlane/android/Fastfile
+++ b/src/templates/fastlane/android/Fastfile
@@ -41,7 +41,7 @@ platform :android do
 
     build_number = number_of_commits()
     gradle(
-      task: 'assemble',
+      task: 'bundle',
       build_type: build_type,
       properties: {
         "VERSION_CODE" => build_number
@@ -79,7 +79,7 @@ platform :android do
     upload_to_play_store(
       package_name:  "<%= props.appId %>#{package_name_postfix}",
       track: 'internal',
-      apk: "./app/build/outputs/apk/#{env}/release/app-#{env}-release.apk"
+      aab: "./app/build/outputs/bundle/#{env}/app.aab"
     )
   end
 end


### PR DESCRIPTION
Changed template Fastfile to use Android App Bundle as default.
Reasons to use .aab include smaller app size and no need to build for separate CPU architectures, as that is handled by the Play Store.
More info here:
https://developer.android.com/platform/technology/app-bundle

As of now, Crashlytics does not support .aab -format.